### PR TITLE
Typo on "Isabelle Huteau" name (missing "a")

### DIFF
--- a/_includes/organizers.html
+++ b/_includes/organizers.html
@@ -32,7 +32,7 @@
               <p>Karine Zeitouni
                 <br>
                 <small>USVQ, UPsay</small></p>
-              <p>Isablle Huteau
+              <p>Isabelle Huteau
                   <br>
                   <small>Digicosme</small></p>
             </div>


### PR DESCRIPTION
Just read the [homepage](https://bigmine.github.io/jDSParis16/#call), only tiny typing mistake I could find.

Nice work, it's a very nice small website!
